### PR TITLE
fixed custom builds

### DIFF
--- a/BuildBotLib/make.py
+++ b/BuildBotLib/make.py
@@ -29,6 +29,9 @@ class Make(BaseModule):
             begin = max(repository.rfind('/', 0, begin),
                         repository.rfind(':', 0, begin))
 
+            if begin < 0:
+                return "build"
+
             project = repository[begin + 1:len(repository)]
             return project
 

--- a/BuildBotLib/make.py
+++ b/BuildBotLib/make.py
@@ -12,8 +12,27 @@ class Make(BaseModule):
     def __init__(self, platform):
         BaseModule.__init__(self,
                             platform,
-                            util.Interpolate('%(prop:project)s'))
+                            self.getProject())
         self.tempRepoDir = ""
+
+    def getProject(self):
+
+        @util.renderer
+        def cmdWraper(step):
+            repository = step.getProperty('repository')
+
+            if not len(repository):
+                return "build"
+
+            repository = repository.replace('.git', '')
+            begin = repository.rfind('/')
+            begin = max(repository.rfind('/', 0, begin),
+                        repository.rfind(':', 0, begin))
+
+            project = repository[begin + 1:len(repository)]
+            return project
+
+        return cmdWraper
 
     def isSupport(self, step):
         return True


### PR DESCRIPTION
The method **getProject** should return a decorator of a function that extract a repo url from a git urls
tested on 
* https://github.com/QuasarApp/QuasarAppCI.git
* https://github.com/QuasarApp/QuasarAppCI
* git@github.com:QuasarApp/QuasarAppCI.git

fix #14 